### PR TITLE
Delete temp files immediately after using them

### DIFF
--- a/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageReader.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageReader.java
@@ -49,14 +49,13 @@ final class JpegImageReader {
         try {
             File tempFile = File.createTempFile("tmp", ".jpg");
             FileOutputStream fos = new FileOutputStream(tempFile);
+
             fos.write(bytes);
-
-            BufferedImage image = ImageIO.read(tempFile);
-
             fos.flush();
             fos.close();
-            tempFile.delete();
 
+            BufferedImage image = ImageIO.read(tempFile);
+            tempFile.delete();
             return image;
         } catch (IOException e) {
             throw new JpegAutorotateException("Unable to read JPEG image.", e);

--- a/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageReader.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageReader.java
@@ -47,7 +47,7 @@ final class JpegImageReader {
      */
     protected static BufferedImage readImage(final byte[] bytes) throws JpegAutorotateException {
         try {
-            File tempFile = File.createTempFile("tmp", "jpg");
+            File tempFile = File.createTempFile("tmp", ".jpg");
             FileOutputStream fos = new FileOutputStream(tempFile);
             fos.write(bytes);
 
@@ -55,7 +55,7 @@ final class JpegImageReader {
 
             fos.flush();
             fos.close();
-            tempFile.deleteOnExit();
+            tempFile.delete();
 
             return image;
         } catch (IOException e) {

--- a/src/test/java/com/domenicseccareccia/jpegautorotate/JpegAutorotateTest.java
+++ b/src/test/java/com/domenicseccareccia/jpegautorotate/JpegAutorotateTest.java
@@ -131,16 +131,16 @@ public class JpegAutorotateTest {
 
     private void testRotateAndFlipImage(String originalImagePath, String resultImagePath) throws Exception {
         byte[] rotatedImageBytes = JpegAutorotate.rotate(new FileInputStream(new File(originalImagePath)));
-        File tempFile = File.createTempFile("tmp", "jpg");
+        File tempFile = File.createTempFile("tmp", ".jpg");
         FileOutputStream fos = new FileOutputStream(tempFile);
         fos.write(rotatedImageBytes);
 
-        tempFile.deleteOnExit();
         fos.flush();
         fos.close();
 
         BufferedImage originalImage = ImageIO.read(new File(resultImagePath));
         BufferedImage rotatedImage = ImageIO.read(tempFile);
+        tempFile.delete();
 
         int width  = originalImage.getWidth();
         int height = originalImage.getHeight();
@@ -172,15 +172,15 @@ public class JpegAutorotateTest {
 
         // Initialize rotated image
         byte[] rotatedImageBytes = JpegAutorotate.rotate(originalImagePath);
-        File tempFile = File.createTempFile("tmp", "jpg");
+        File tempFile = File.createTempFile("tmp", ".jpg");
         FileOutputStream fos = new FileOutputStream(tempFile);
         fos.write(rotatedImageBytes);
 
-        tempFile.deleteOnExit();
         fos.flush();
         fos.close();
-
         BufferedImage rotatedImage = ImageIO.read(tempFile);
+        tempFile.delete();
+
         JpegImageMetadata rotatedImageMetadata = (org.apache.commons.imaging.formats.jpeg.JpegImageMetadata) Imaging.getMetadata(rotatedImageBytes);
         TiffOutputSet rotatedImageOutputSet = rotatedImageMetadata.getExif().getOutputSet();
 

--- a/src/test/java/com/domenicseccareccia/jpegautorotate/JpegAutorotateTest.java
+++ b/src/test/java/com/domenicseccareccia/jpegautorotate/JpegAutorotateTest.java
@@ -133,8 +133,8 @@ public class JpegAutorotateTest {
         byte[] rotatedImageBytes = JpegAutorotate.rotate(new FileInputStream(new File(originalImagePath)));
         File tempFile = File.createTempFile("tmp", ".jpg");
         FileOutputStream fos = new FileOutputStream(tempFile);
-        fos.write(rotatedImageBytes);
 
+        fos.write(rotatedImageBytes);
         fos.flush();
         fos.close();
 
@@ -174,10 +174,11 @@ public class JpegAutorotateTest {
         byte[] rotatedImageBytes = JpegAutorotate.rotate(originalImagePath);
         File tempFile = File.createTempFile("tmp", ".jpg");
         FileOutputStream fos = new FileOutputStream(tempFile);
-        fos.write(rotatedImageBytes);
 
+        fos.write(rotatedImageBytes);
         fos.flush();
         fos.close();
+
         BufferedImage rotatedImage = ImageIO.read(tempFile);
         tempFile.delete();
 


### PR DESCRIPTION
Using tempFile.deleteOnExit() causes many temp files (potentially GB's) to pile up over time in my applications /tmp/ folder. 

Deleting them here immediately after using to prevent this.

Also closing output stream before reading from the tempfile.