### PR TITLE
Close all not properly closed Java streams

### DIFF
--- a/src/main/java/com/domenicseccareccia/jpegautorotate/JpegAutorotate.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/JpegAutorotate.java
@@ -125,8 +125,8 @@ public final class JpegAutorotate {
             throw new FileNotFoundException("JPEG file does not exist.");
         }
 
-        try {
-            byte[] bytes = ImageUtils.writeImageToBytes(new FileInputStream(file));
+        try (InputStream is = new FileInputStream(file)) {
+            byte[] bytes = ImageUtils.writeImageToBytes(is);
 
             return JpegImageProcessor.process(bytes);
         } catch (IOException e) {

--- a/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageProcessor.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageProcessor.java
@@ -158,14 +158,11 @@ public final class JpegImageProcessor {
      *              to a {@code byte[]}.
      */
     private static byte[] writeThumbnail(JpegImageMetadata metadata) throws JpegAutorotateException {
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             ImageIO.write(metadata.getThumbnail(), "jpeg", baos);
             baos.flush();
-            byte[] bytes = baos.toByteArray();
-            baos.close();
 
-            return bytes;
+            return baos.toByteArray();
         } catch (IOException e) {
             throw new JpegAutorotateException("Unable to update JPEG image thumbnail.", e);
         }
@@ -187,22 +184,18 @@ public final class JpegImageProcessor {
      *              to a {@code byte[]}.
      */
     private static byte[] writeImage(JpegImage image) throws JpegAutorotateException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        try {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             ImageIO.write(image.getImage(), "jpeg", baos);
             byte [] data = baos.toByteArray();
             baos.reset();
 
             // Update JPEG image metadata
-            baos = new ByteArrayOutputStream();
             new ExifRewriter().updateExifMetadataLossless(data, baos, image.getMetadata().getOutputSet());
             data = baos.toByteArray();
             baos.reset();
 
             // Update IPTC/Photoshop metadata
             if (image.getMetadata().getPhotoshop() != null) {
-                baos = new ByteArrayOutputStream();
                 new JpegIptcRewriter().writeIPTC(data, baos, image.getMetadata().getPhotoshop().photoshopApp13Data);
                 data = baos.toByteArray();
                 baos.reset();
@@ -210,13 +203,9 @@ public final class JpegImageProcessor {
 
             // Update XMP metadata
             if (image.getMetadata().getXmpXml() != null) {
-                baos = new ByteArrayOutputStream();
                 new JpegXmpRewriter().updateXmpXml(data, baos, image.getMetadata().getXmpXml());
                 data = baos.toByteArray();
-                baos.reset();
             }
-
-            baos.close();
 
             return data;
         } catch (ImageWriteException | ImageReadException | IOException e) {

--- a/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageReader.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/imaging/JpegImageReader.java
@@ -26,6 +26,7 @@ import com.domenicseccareccia.jpegautorotate.JpegAutorotateException;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.*;
+import java.nio.file.Files;
 
 final class JpegImageReader {
 
@@ -48,14 +49,15 @@ final class JpegImageReader {
     protected static BufferedImage readImage(final byte[] bytes) throws JpegAutorotateException {
         try {
             File tempFile = File.createTempFile("tmp", ".jpg");
-            FileOutputStream fos = new FileOutputStream(tempFile);
 
-            fos.write(bytes);
-            fos.flush();
-            fos.close();
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(bytes);
+                fos.flush();
+            }
 
             BufferedImage image = ImageIO.read(tempFile);
             tempFile.delete();
+
             return image;
         } catch (IOException e) {
             throw new JpegAutorotateException("Unable to read JPEG image.", e);

--- a/src/main/java/com/domenicseccareccia/jpegautorotate/util/ImageUtils.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/util/ImageUtils.java
@@ -70,8 +70,8 @@ public final class ImageUtils {
      *              In the event the image file type is unable to be determined.
      */
     public static boolean isAcceptableImage(final byte[] bytes) throws JpegAutorotateException {
-        try {
-            String contentType = URLConnection.guessContentTypeFromStream(new ByteArrayInputStream(bytes));
+        try (InputStream is = new ByteArrayInputStream(bytes)) {
+            String contentType = URLConnection.guessContentTypeFromStream(is);
 
             return FILENAME_FILTER.accept(null, contentType);
         } catch (IOException e) {
@@ -90,9 +90,7 @@ public final class ImageUtils {
      *              to a {@code byte[]}.
      */
     public static byte[] writeImageToBytes(final InputStream is) throws JpegAutorotateException {
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             IOUtils.copy(is, baos);
 
             return baos.toByteArray();

--- a/src/main/java/com/domenicseccareccia/jpegautorotate/util/ImageUtils.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/util/ImageUtils.java
@@ -90,10 +90,8 @@ public final class ImageUtils {
      *              to a {@code byte[]}.
      */
     public static byte[] writeImageToBytes(final InputStream is) throws JpegAutorotateException {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            IOUtils.copy(is, baos);
-
-            return baos.toByteArray();
+        try {
+            return IOUtils.toByteArray(is);
         } catch (IOException e) {
             throw new JpegAutorotateException("Unable to read/write InputStream containing JPEG image data to a byte array.", e);
         }

--- a/src/test/java/com/domenicseccareccia/jpegautorotate/util/ImageUtilsTest.java
+++ b/src/test/java/com/domenicseccareccia/jpegautorotate/util/ImageUtilsTest.java
@@ -40,7 +40,7 @@ public class ImageUtilsTest {
         // JPEG Image
         assertTrue(ImageUtils.isAcceptableImage(new File(JPEG_IMAGE)));
 
-        try (InputStream is = new FileInputStream(new File(JPEG_IMAGE))) {
+        try (InputStream is = new FileInputStream(JPEG_IMAGE)) {
             byte[] bytes = ImageUtils.writeImageToBytes(is);
 
             assertTrue(ImageUtils.isAcceptableImage(bytes));
@@ -49,7 +49,7 @@ public class ImageUtilsTest {
         // PNG Image
         assertFalse(ImageUtils.isAcceptableImage(new File(PNG_IMAGE)));
 
-        try (InputStream is = new FileInputStream(new File(PNG_IMAGE))) {
+        try (InputStream is = new FileInputStream(PNG_IMAGE)) {
             byte[] bytes = ImageUtils.writeImageToBytes(is);
 
             assertFalse(ImageUtils.isAcceptableImage(bytes));
@@ -59,10 +59,12 @@ public class ImageUtilsTest {
     @Test
     public void testWriteImageToBytes() throws Exception {
         // JPEG Image
-        InputStream is = new FileInputStream(new File(JPEG_IMAGE));
-        byte[] expectedBytes = IOUtils.toByteArray(is);
+        try (InputStream is = new FileInputStream(JPEG_IMAGE);
+             InputStream is2 = new FileInputStream(JPEG_IMAGE)) {
+            byte[] expectedBytes = IOUtils.toByteArray(is);
 
-        assertArrayEquals(expectedBytes, ImageUtils.writeImageToBytes(new FileInputStream(new File(JPEG_IMAGE))));
+            assertArrayEquals(expectedBytes, ImageUtils.writeImageToBytes(is2));
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #13 

- All streams (i.e. `ByteArrayOutputStream`) are now closed within a `try-with-resources` block
- All streams that were previously closed inside a `try-catch-finally` block have been refactored to use a `try-with-resources` block

