### PR TITLE
Manually changing non JPEG file extensions to .jpg are now rejected

### DIFF
--- a/src/main/java/com/domenicseccareccia/jpegautorotate/JpegAutorotate.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/JpegAutorotate.java
@@ -117,18 +117,12 @@ public final class JpegAutorotate {
      *              In the event the JPEG file does not exist.
      */
     public static byte[] rotate(final File file) throws JpegAutorotateException, FileNotFoundException {
-        if (!ImageUtils.isJpeg(file)) {
-            throw new JpegAutorotateException("File is not compatible, must be a JPEG image.");
-        }
-
         if (!file.isFile() && !file.exists()) {
             throw new FileNotFoundException("JPEG file does not exist.");
         }
 
         try (InputStream is = new FileInputStream(file)) {
-            byte[] bytes = ImageUtils.toByteArray(is);
-
-            return JpegImageProcessor.process(bytes);
+            return rotate(is);
         } catch (IOException e) {
             throw new JpegAutorotateException("Unable to read JPEG file.", e);
         }

--- a/src/main/java/com/domenicseccareccia/jpegautorotate/util/ImageUtils.java
+++ b/src/main/java/com/domenicseccareccia/jpegautorotate/util/ImageUtils.java
@@ -21,7 +21,6 @@
 package com.domenicseccareccia.jpegautorotate.util;
 
 import com.domenicseccareccia.jpegautorotate.JpegAutorotateException;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
@@ -48,17 +47,6 @@ public final class ImageUtils {
 
         return false;
     };
-
-    /**
-     * Attempts to determine if the {@code file} is a JPEG image.
-     *
-     * @param file
-     *              {@code File} containing image data.
-     * @return {@code true} If the {@code file} type is a JPEG image; otherwise, false.
-     */
-    public static boolean isJpeg(final File file) {
-        return FILENAME_FILTER.accept(file, FilenameUtils.getExtension(file.getName()));
-    }
 
     /**
      * Attempts to determine if the {@code bytes} is a JPEG image file.

--- a/src/test/java/com/domenicseccareccia/jpegautorotate/util/ImageUtilsTest.java
+++ b/src/test/java/com/domenicseccareccia/jpegautorotate/util/ImageUtilsTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2019-2020 Domenic Seccareccia and contributors
- *
+ * <p>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,11 +23,11 @@ package com.domenicseccareccia.jpegautorotate.util;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImageUtilsTest {
 
@@ -37,8 +37,6 @@ public class ImageUtilsTest {
     @Test
     public void testIsJpeg() throws Exception {
         // JPEG Image
-        assertTrue(ImageUtils.isJpeg(new File(JPEG_IMAGE)));
-
         try (InputStream is = new FileInputStream(JPEG_IMAGE)) {
             byte[] bytes = ImageUtils.toByteArray(is);
 
@@ -46,8 +44,6 @@ public class ImageUtilsTest {
         }
 
         // PNG Image
-        assertFalse(ImageUtils.isJpeg(new File(PNG_IMAGE)));
-
         try (InputStream is = new FileInputStream(PNG_IMAGE)) {
             byte[] bytes = ImageUtils.toByteArray(is);
 


### PR DESCRIPTION
Fixes #17 

- Any non JPEG file that has its extension changed to .jpg before library processing will be rejected
- All `rotate()` methods will now call upon the `rotate(final InputStream inputStream)` method to handle JPEG image processing and rotation
- JPEG image file validation is now checked for paths and files by checking the file content type within an input stream instead of solely looking at the file extension