### PR TITLE
Updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,23 +44,23 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-imaging</artifactId>
-            <version>1.0-alpha1</version>
+            <version>1.0-alpha2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.2</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Closes #25 

- commons-io to 2.8.0
- commons-imaging to 1.0-alpha2
- junit-jupiter-api to 5.7.0
- junit-jupiter-engine to 5.7.0