### PR TITLE
Add missing license

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The following icon changes were made:
 - Stroke width decreased for all icons by 0.25
 - Detached arrows from [sync-alt](https://fontawesome.com/icons/sync-alt?style=solid)
 
+### Original project
+
+- [johansatge/jpeg-autorotate](https://github.com/johansatge/jpeg-autorotate)
+
 ### Other
 
 - [EXIF Info](https://exifinfo.org/)


### PR DESCRIPTION
Hello,

thank you for publishing open-source work on GitHub!

It seems your project is missing some licensing information.

The readme, logo, and project name have been copied from [johansatge/jpeg-autorotate](https://github.com/johansatge/jpeg-autorotate), which is fine, because its MIT license allows derivative work. But in order to respect said license, you also need to credit the original project; hence, this pull request.

(It may not be obvious, but the name of a project, its _readme_, and all other assets are part of it, and are covered by its license. A license does not only cover the source code of a project!)

Thank you and have a nice day!

--- 
![2](https://user-images.githubusercontent.com/91780099/135710187-b5c6ad0e-215b-4c8c-b7ee-1b94a7147e77.png)
---
![1](https://user-images.githubusercontent.com/91780099/135710189-e4f6b7e3-96f3-47eb-9218-b0421ab14a66.png)
---
![3](https://user-images.githubusercontent.com/91780099/135710190-a28fc81b-e8da-4969-b698-b91eb72b3122.png)
---
![4](https://user-images.githubusercontent.com/91780099/135710192-517dda13-e61c-4827-8461-a9b3530e3685.png)
